### PR TITLE
Note macOS Homebrew install in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,6 +24,13 @@ Deleted files get sent to the graveyard (=/tmp/graveyard-$USER= by default, see 
    #+BEGIN_EXAMPLE
    $ yay -S rm-improved
    #+END_EXAMPLE
+   
+   macOS users can install it with Homebrew:
+
+   #+BEGIN_EXAMPLE
+   $ brew install rm-improved
+   #+END_EXAMPLE
+
 ** ⚰ Usage
    #+BEGIN_EXAMPLE
    USAGE:


### PR DESCRIPTION
Resolves #14. ~~This is conditional based on https://github.com/Homebrew/homebrew-core/pull/64107/ merging, so I am leaving it as a draft until then.~~ `rm-improved` is now available via Homebrew.